### PR TITLE
Use the official Ubuntu AMI.

### DIFF
--- a/template.json
+++ b/template.json
@@ -28,6 +28,12 @@
       "type": "shell",
       "script": "provision.sh",
       "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E '{{ .Path }}'"
+    },
+    {
+      "type":   "shell",
+      "inline": [
+          "rm /home/ubuntu/.ssh/authorized_keys"
+      ]
     }
   ]
 }

--- a/template.json
+++ b/template.json
@@ -3,7 +3,7 @@
     "aws_access_key": "",
     "aws_secret_key": "",
     "region": "eu-west-1",
-    "source_ami": "ami-8ac04ff9",
+    "source_ami": "ami-6f587e1c",
     "ssh_username": "ubuntu",
     "name": "openvpn"
   },


### PR DESCRIPTION
This is the option listed on the "Quick start" tab of the AMI selector
in AWS. The previous AMI comes from an unknown source and contains an
unknown and weird entry in authorized_keys which was determined to have
come from the base AMI that was being used. Since the image in question
was of unknown provenance, it has been assumed to be compromised and
therefore replaced with a known good one.